### PR TITLE
Fix - AuthorDate format, inProceedings

### DIFF
--- a/utmthesis-authordate.bst
+++ b/utmthesis-authordate.bst
@@ -535,7 +535,7 @@ FUNCTION {format.note}
 FUNCTION {format.month}
 {
   month empty$
-    'skip$
+    { "" }
     { " " month * }
   if$
 }


### PR DESCRIPTION
inProceeding References without month field are erroneously crashing BibTEX when using AuthorDate format; as reported in https://tex.stackexchange.com/questions/325008/utmthesis-error-you-cant-pop-an-empty-literal-stack-for-entry. 
Fix returns an empty string for month formatting option, instead of skipping.